### PR TITLE
Support raml 1 spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "dependencies": {
     "async": "~0.9.0",
-    "commander": "~2.5.0",
     "colors": "~1.0.3",
-    "raml-parser": "~0.8.7"
+    "commander": "~2.5.0",
+    "raml-1-parser": "^1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Use new raml-1-parser which supports both vers 0.8 and 1
of RAML
Closes #3