### PR TITLE
Use error path so that file names display properly

### DIFF
--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -6,6 +6,7 @@ const Bluebird  = require('bluebird');
 const colors    = require('colors');
 const commander = require('commander');
 const raml      = require('raml-1-parser');
+const path      = require('path');
 const pkg       = require('../package.json');
 
 const outputSuccess = function (name) {
@@ -20,7 +21,7 @@ const outputFailure = function (name, err) {
   if (err.parserErrors) {
 
     err.parserErrors.forEach((e) => {
-      let src = e.path;
+      let src = path.join(path.dirname(name), e.path);
       let line = e.range.start.line;
       let column = e.range.start.column;
       let msg = colors.red(e.message);

--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -20,7 +20,7 @@ const outputFailure = function (name, err) {
   if (err.parserErrors) {
 
     err.parserErrors.forEach((e) => {
-      let src = (name === '-') ? 'STDIN' : name;
+      let src = e.path;
       let line = e.range.start.line;
       let column = e.range.start.column;
       let msg = colors.red(e.message);


### PR DESCRIPTION
Previously the top-level input name was always used, which resulted in
the file path being incorrect for errors in included files.
