### PR TITLE
Add color and ignore-flag for warnings

### DIFF
--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -27,24 +27,21 @@ const validate = function (filename, options) {
     .resolve()
     .then(() => {
 
-      return raml.loadRAML(filename, [], { rejectOnErrors: true });
-    })
-    .then(() => {
-
-      return { src: filename, message: 'VALID' };
+      return raml.loadRAML(filename);
     })
     .catch((err) => {
-
-      const errorsToReport = [];
-
       // Generic error
       if (!err.parserErrors) {
         err.results = [{ src: filename, message: err.message, isWarning: err.isWarning }];
         throw err;
-      }
+      } 
+    })
+    .then((ramlContent) => {
+
+      const errorsToReport = [];
 
       // RAML parser error
-      err.parserErrors.forEach((e) => {
+      ramlContent.errors().forEach((e) => {
 
         let errFilename = path.join(path.dirname(filename), e.path);
 
@@ -72,7 +69,7 @@ const validate = function (filename, options) {
       } else {
 
         return { src: filename, message: 'VALID' };
-      }
+      }   
     });
 };
 

--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -18,6 +18,7 @@ const validate = function (filename, options) {
 
   const defaultOptions = {
     reportIncludeErrors: true,
+    reportIncludeWarnings: true,
   };
 
   const mergedOptions = Object.assign({}, defaultOptions, options || {});
@@ -47,7 +48,8 @@ const validate = function (filename, options) {
 
         let errFilename = path.join(path.dirname(filename), e.path);
 
-        if (!mergedOptions.reportIncludeErrors && errFilename !== filename) {
+        if ((!mergedOptions.reportIncludeErrors && errFilename !== filename) || 
+          (!mergedOptions.reportIncludeWarnings && e.isWarning)) {
           return;
         }
 
@@ -81,6 +83,7 @@ commander
   .usage('[options] <file ...>')
   .option('    --no-color', 'disable colored output')
   .option('    --no-includes', 'do not report errors for include files')
+  .option('    --no-warnings', 'do not report warnings')
   .parse(process.argv);
 
 // --no-colors option
@@ -89,6 +92,11 @@ commander
 // --no-includes options
 if (!commander.includes) {
   validationOptions.reportIncludeErrors = false;
+}
+
+// --no-warnings options
+if (!commander.warnings) {
+  validationOptions.reportIncludeWarnings = false;
 }
 
 // If there are no files to process, then display the usage message

--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -38,7 +38,7 @@ const validate = function (filename, options) {
 
       // Generic error
       if (!err.parserErrors) {
-        err.results = [{ src: filename, message: err.message }];
+        err.results = [{ src: filename, message: err.message, isWarning: err.isWarning }];
         throw err;
       }
 
@@ -54,6 +54,7 @@ const validate = function (filename, options) {
         errorsToReport.push({
           src: `${errFilename}:${e.range.start.line}:${e.range.start.column}`,
           message: e.message,
+          isWarning: e.isWarning
         });
       });
 
@@ -110,7 +111,12 @@ Bluebird
 
         // Something went wrong. Display error message for each error
         err.results.forEach((e) => {
-          console.log(`[${e.src}] ${colors.red(e.message)}`);
+
+          if (e.isWarning) {
+            console.log(`[${e.src}] ${colors.yellow(e.message)}`);
+          } else {
+            console.log(`[${e.src}] ${colors.red(e.message)}`);
+          }
           errorCount++;
         });
       });

--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -48,8 +48,11 @@ const validate = function (filename, options) {
 
         let errFilename = path.join(path.dirname(filename), e.path);
 
-        if ((!mergedOptions.reportIncludeErrors && errFilename !== filename) || 
-          (!mergedOptions.reportWarnings && e.isWarning)) {
+        if (!mergedOptions.reportIncludeErrors && errFilename !== filename) {
+          return;
+        }
+
+        if (!mergedOptions.reportWarnings && e.isWarning) {
           return;
         }
 

--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -18,7 +18,7 @@ const validate = function (filename, options) {
 
   const defaultOptions = {
     reportIncludeErrors: true,
-    reportIncludeWarnings: true,
+    reportWarnings: true,
   };
 
   const mergedOptions = Object.assign({}, defaultOptions, options || {});
@@ -49,7 +49,7 @@ const validate = function (filename, options) {
         let errFilename = path.join(path.dirname(filename), e.path);
 
         if ((!mergedOptions.reportIncludeErrors && errFilename !== filename) || 
-          (!mergedOptions.reportIncludeWarnings && e.isWarning)) {
+          (!mergedOptions.reportWarnings && e.isWarning)) {
           return;
         }
 
@@ -96,7 +96,7 @@ if (!commander.includes) {
 
 // --no-warnings options
 if (!commander.warnings) {
-  validationOptions.reportIncludeWarnings = false;
+  validationOptions.reportWarnings = false;
 }
 
 // If there are no files to process, then display the usage message

--- a/src/raml-cop.js
+++ b/src/raml-cop.js
@@ -32,7 +32,7 @@ const validate = function (filename, options) {
     .catch((err) => {
       // Generic error
       if (!err.parserErrors) {
-        err.results = [{ src: filename, message: err.message, isWarning: err.isWarning }];
+        err.results = [{ src: filename, message: err.message}];
         throw err;
       } 
     })

--- a/test/0.8/0.8-tests.js
+++ b/test/0.8/0.8-tests.js
@@ -338,4 +338,66 @@ describe('RAML 0.8 Tests', function () {
       chai.expect(stdoutLines[2]).to.contain(files[2]);
     });
   });
+
+  describe('Invalid file with one error and one warning (default)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-error-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, [file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename, line number, column number, and message for both error and warning', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+\r?\n\[.+:[0-9]+:[0-9]+\] .+/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 1', function() {
+      chai.expect(results.code).to.eql(1);
+    });
+  });
+
+  describe('Invalid file with one error and one warning (--no-warnings)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-error-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, ['--no-warnings', file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename, line number, column number, and message only for error', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 1', function() {
+      chai.expect(results.code).to.eql(1);
+    });
+  });
 });

--- a/test/0.8/0.8-tests.js
+++ b/test/0.8/0.8-tests.js
@@ -339,6 +339,68 @@ describe('RAML 0.8 Tests', function () {
     });
   });
 
+  describe('Invalid file with one warning (default)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, [file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename, line number, column number, and message for both error and warning', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 1', function() {
+      chai.expect(results.code).to.eql(1);
+    });
+  });
+
+  describe('Invalid file with one warning (--no-warnings)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, ['--no-warnings', file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename and "VALID"', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+\] VALID/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 0', function() {
+      chai.expect(results.code).to.eql(0);
+    });
+  });
+
   describe('Invalid file with one error and one warning (default)', function () {
 
     const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');

--- a/test/0.8/0.8-tests.js
+++ b/test/0.8/0.8-tests.js
@@ -356,7 +356,7 @@ describe('RAML 0.8 Tests', function () {
       });
     });
 
-    it ('STDOUT should contain filename, line number, column number, and message for both the warning', function() {
+    it ('STDOUT should contain filename, line number, column number, and message for the warning', function() {
       chai.expect(results.stdout).to.contain(file);
       chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
     });

--- a/test/0.8/0.8-tests.js
+++ b/test/0.8/0.8-tests.js
@@ -356,7 +356,7 @@ describe('RAML 0.8 Tests', function () {
       });
     });
 
-    it ('STDOUT should contain filename, line number, column number, and message for both error and warning', function() {
+    it ('STDOUT should contain filename, line number, column number, and message for both the warning', function() {
       chai.expect(results.stdout).to.contain(file);
       chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
     });

--- a/test/0.8/data/invalid-one-error-one-warning.raml
+++ b/test/0.8/data/invalid-one-error-one-warning.raml
@@ -1,0 +1,34 @@
+#%RAML 0.8
+title: One Error
+version: v1
+protocols: HTTPS
+mediaType: application/json
+
+/hello:
+
+  get:
+    description: An example endpoint
+    responses:
+        200:
+          body:
+            application/json:
+              schema: |
+                {
+                  "properties" : {
+                    "hello": 
+                      {
+                        "type" : "string",
+                        "required" : true
+                      }
+                    }
+                }
+              example: |
+                {
+                  "hello": false
+                }
+
+/world:
+
+  get:
+    description: 
+    Another example endpoint

--- a/test/0.8/data/invalid-one-warning.raml
+++ b/test/0.8/data/invalid-one-warning.raml
@@ -1,0 +1,34 @@
+#%RAML 0.8
+title: One Error
+version: v1
+protocols: HTTPS
+mediaType: application/json
+
+/hello:
+
+  get:
+    description: An example endpoint
+    responses:
+        200:
+          body:
+            application/json:
+              schema: |
+                {
+                  "properties" : {
+                    "hello": 
+                      {
+                        "type" : "string",
+                        "required" : true
+                      }
+                    }
+                }
+              example: |
+                {
+                  "hello": false
+                }
+
+/world:
+
+  get:
+    description: 
+      Another example endpoint

--- a/test/1.0/1.0-tests.js
+++ b/test/1.0/1.0-tests.js
@@ -338,4 +338,66 @@ describe('RAML 1.0 Tests', function () {
       chai.expect(stdoutLines[2]).to.contain(files[2]);
     });
   });
+
+  describe('Invalid file with one error and one warning (default)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-error-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, [file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename, line number, column number, and message for both error and warning', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+\r?\n\[.+:[0-9]+:[0-9]+\] .+/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 1', function() {
+      chai.expect(results.code).to.eql(1);
+    });
+  });
+
+  describe('Invalid file with one error and one warning (--no-warnings)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-error-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, ['--no-warnings', file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename, line number, column number, and message only for error', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 1', function() {
+      chai.expect(results.code).to.eql(1);
+    });
+  });
 });

--- a/test/1.0/1.0-tests.js
+++ b/test/1.0/1.0-tests.js
@@ -356,7 +356,7 @@ describe('RAML 1.0 Tests', function () {
       });
     });
 
-    it ('STDOUT should contain filename, line number, column number, and message for both error and warning', function() {
+    it ('STDOUT should contain filename, line number, column number, and message for the warning', function() {
       chai.expect(results.stdout).to.contain(file);
       chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
     });

--- a/test/1.0/1.0-tests.js
+++ b/test/1.0/1.0-tests.js
@@ -339,6 +339,68 @@ describe('RAML 1.0 Tests', function () {
     });
   });
 
+  describe('Invalid file with one warning (default)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, [file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename, line number, column number, and message for both error and warning', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+:[0-9]+:[0-9]+\] .+/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 1', function() {
+      chai.expect(results.code).to.eql(1);
+    });
+  });
+
+  describe('Invalid file with one warning (--no-warnings)', function () {
+
+    const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');
+    const file    = path.join(__dirname, 'data', 'invalid-one-warning.raml');
+    
+    let results = {};
+      
+    before(function (done) {
+
+      testChildProcess(ramlCop, ['--no-warnings', file], (err, data) => {
+        if (err) { return done(err); }
+
+        results = data;
+        done();
+      });
+    });
+
+    it ('STDOUT should contain filename and "VALID"', function() {
+      chai.expect(results.stdout).to.contain(file);
+      chai.expect(results.stdout).to.match(/^\[.+\] VALID/);
+    });
+
+    it ('STDERR should be empty', function() {
+      chai.expect(results.stderr).to.be.empty;
+    });
+
+    it('Should exit with code 0', function() {
+      chai.expect(results.code).to.eql(0);
+    });
+  });
+
   describe('Invalid file with one error and one warning (default)', function () {
 
     const ramlCop = path.join(__dirname, '..', '..', 'src', 'raml-cop.js');

--- a/test/1.0/data/invalid-one-error-one-warning.raml
+++ b/test/1.0/data/invalid-one-error-one-warning.raml
@@ -1,0 +1,26 @@
+#%RAML 1.0
+title: One Error One Warning
+description: This document has one error and one warning
+version: v1
+protocols: HTTPS
+mediaType: application/json
+
+/hello:
+
+  get:
+    description: An example endpoint
+    responses:
+        200:
+          body:
+            application/json:
+              properties:
+                hello: string
+              example: 
+                hello: hola
+                world: mundo
+
+/world:
+
+  get:
+    description: 
+    Another example endpoint

--- a/test/1.0/data/invalid-one-warning.raml
+++ b/test/1.0/data/invalid-one-warning.raml
@@ -1,0 +1,26 @@
+#%RAML 1.0
+title: One Error One Warning
+description: This document has one error and one warning
+version: v1
+protocols: HTTPS
+mediaType: application/json
+
+/hello:
+
+  get:
+    description: An example endpoint
+    responses:
+        200:
+          body:
+            application/json:
+              properties:
+                hello: string
+              example: 
+                hello: hola
+                world: mundo
+
+/world:
+
+  get:
+    description: 
+      Another example endpoint


### PR DESCRIPTION
I am using raml-cop to validate my RAMLs, and I love this tool, but I think it would be great to make difference between warnings and errors when printing the console report.

In this PR I have a few changes:
-add a flag to validate() to mark errors as warnings
-print errors flagged as warning in yellow (errors are still in red)
-allow to ignore warnings messages